### PR TITLE
docs: add `go install` option to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,13 @@ curl -fsSL https://sh.haloy.dev/install-haloy.sh | sh
 brew install haloydev/tap/haloy
 ```
 
-**npm/pnpm/bun**
+**Go:**
+
+```bash
+go install github.com/haloydev/haloy/cmd/haloy@latest
+```
+
+**npm/pnpm/bun:**
 ```bash
 npm i -g haloy
 


### PR DESCRIPTION
As a Go developer, I often prefer installing pure Go projects directly with `go install` rather than additional package managers.

I added simple instructions to the README.
Also updated the website documentation: https://github.com/haloydev/web/pull/3