### PR TITLE
chore(ci): use Go version from go.mod instead of hardcoded 1.26.5

### DIFF
--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.5'
+          go-version-file: go.mod
 
       - name: Install Task
         uses: go-task/setup-task@v2
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.5'
+          go-version-file: go.mod
 
       - name: Determine Version
         id: get_version

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.5'
+          go-version-file: go.mod
           cache: false
 
       - name: Install Task
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.5'
+          go-version-file: go.mod
           cache: false
 
       - name: Install Task


### PR DESCRIPTION
Replace hardcoded `go-version: '1.26.5'` with `go-version-file: go.mod` in CI.

Single source of truth + easier future bumps.