### PR TITLE
feat: logs `--no-follow` and `--raw` flag

### DIFF
--- a/internal/api/handlers_logs.go
+++ b/internal/api/handlers_logs.go
@@ -28,6 +28,7 @@ func (s *APIServer) handleAppLogs() http.HandlerFunc {
 		}
 		containerIDParam := r.URL.Query().Get("containerId")
 		allContainers := r.URL.Query().Get("allContainers") == "true"
+		follow := r.URL.Query().Get("follow") != "false"
 
 		ctx := r.Context()
 
@@ -46,7 +47,7 @@ func (s *APIServer) handleAppLogs() http.HandlerFunc {
 
 		var channels []<-chan docker.LogLine
 		for _, id := range targetIDs {
-			ch, err := docker.StreamContainerLogs(ctx, cli, id, tail)
+			ch, err := docker.StreamContainerLogs(ctx, cli, id, tail, follow)
 			if err != nil {
 				http.Error(w, fmt.Sprintf("failed to stream logs for container: %v", err), http.StatusInternalServerError)
 				return

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -639,7 +639,7 @@ type LogLine struct {
 	Line        string `json:"line"`
 }
 
-func StreamContainerLogs(ctx context.Context, cli *client.Client, containerID string, tail int) (<-chan LogLine, error) {
+func StreamContainerLogs(ctx context.Context, cli *client.Client, containerID string, tail int, follow bool) (<-chan LogLine, error) {
 	if tail <= 0 {
 		tail = 100
 	}
@@ -647,7 +647,7 @@ func StreamContainerLogs(ctx context.Context, cli *client.Client, containerID st
 	options := container.LogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
-		Follow:     true,
+		Follow:     follow,
 		Tail:       fmt.Sprintf("%d", tail),
 		Timestamps: false,
 	}

--- a/internal/haloy/logs.go
+++ b/internal/haloy/logs.go
@@ -97,7 +97,7 @@ Examples:
 	cmd.Flags().StringVarP(&flags.configPath, "config", "c", "", "Path to config file or directory (default: .)")
 	cmd.Flags().StringSliceVarP(&flags.targets, "targets", "t", nil, "Stream logs for specific targets (comma-separated)")
 	cmd.Flags().BoolVarP(&flags.all, "all", "a", false, "Stream logs for all targets")
-	cmd.Flags().IntVar(&tail, "tail", 100, "Number of historical log lines to show (default: 100)")
+	cmd.Flags().IntVar(&tail, "tail", 100, "Number of historical log lines to show")
 	cmd.Flags().StringVar(&containerID, "container", "", "Stream logs from a specific container ID")
 	cmd.Flags().BoolVar(&allContainers, "all-containers", false, "Stream logs from all containers")
 	cmd.Flags().BoolVar(&noFollow, "no-follow", false, "Print existing logs and exit without following")

--- a/internal/haloy/logs.go
+++ b/internal/haloy/logs.go
@@ -21,6 +21,7 @@ func LogsCmd(configPath *string, flags *appCmdFlags) *cobra.Command {
 		allContainers bool
 		containerID   string
 		tail          int
+		noFollow      bool
 		raw           bool
 	)
 
@@ -50,7 +51,10 @@ Examples:
   # Stream from specific targets (multi-target config)
   haloy logs --targets prod
 
-  # Raw dump (no follow, no extra formatting)
+  # Print existing logs and exit without following
+  haloy logs --no-follow
+
+  # Raw logs, no container names, no extra formatting
   haloy logs --raw`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -82,7 +86,7 @@ Examples:
 					if len(targets) > 1 {
 						prefix = target.TargetName
 					}
-					return streamAppLogs(ctx, &target, target.Server, target.Name, tail, containerID, allContainers, raw, prefix)
+					return streamAppLogs(ctx, &target, target.Server, target.Name, tail, containerID, allContainers, !noFollow, raw, prefix)
 				})
 			}
 
@@ -96,14 +100,15 @@ Examples:
 	cmd.Flags().IntVar(&tail, "tail", 100, "Number of historical log lines to show (default: 100)")
 	cmd.Flags().StringVar(&containerID, "container", "", "Stream logs from a specific container ID")
 	cmd.Flags().BoolVar(&allContainers, "all-containers", false, "Stream logs from all containers")
-	cmd.Flags().BoolVar(&raw, "raw", false, "Raw dump (no follow, no extra formatting)")
+	cmd.Flags().BoolVar(&noFollow, "no-follow", false, "Print existing logs and exit without following")
+	cmd.Flags().BoolVar(&raw, "raw", false, "Raw logs with no extra formatting")
 
 	cmd.RegisterFlagCompletionFunc("targets", completeTargetNames)
 
 	return cmd
 }
 
-func streamAppLogs(ctx context.Context, targetConfig *config.TargetConfig, targetServer, appName string, tail int, containerID string, allContainers, raw bool, prefix string) error {
+func streamAppLogs(ctx context.Context, targetConfig *config.TargetConfig, targetServer, appName string, tail int, containerID string, allContainers, follow bool, raw bool, prefix string) error {
 	pui := &ui.PrefixedUI{Prefix: prefix}
 
 	token, err := getToken(targetConfig, targetServer)
@@ -116,7 +121,7 @@ func streamAppLogs(ctx context.Context, targetConfig *config.TargetConfig, targe
 		return &PrefixedError{Err: fmt.Errorf("failed to create API client: %w", err), Prefix: prefix}
 	}
 
-	if !raw {
+	if follow && !raw {
 		pui.Info("Streaming container logs... (Press Ctrl+C to stop)")
 	}
 
@@ -128,7 +133,7 @@ func streamAppLogs(ctx context.Context, targetConfig *config.TargetConfig, targe
 	if allContainers {
 		params.Set("allContainers", "true")
 	}
-	if raw {
+	if !follow {
 		params.Set("follow", "false")
 	}
 

--- a/internal/haloy/logs.go
+++ b/internal/haloy/logs.go
@@ -21,6 +21,7 @@ func LogsCmd(configPath *string, flags *appCmdFlags) *cobra.Command {
 		allContainers bool
 		containerID   string
 		tail          int
+		raw           bool
 	)
 
 	cmd := &cobra.Command{
@@ -47,7 +48,10 @@ Examples:
   haloy logs --container abc123
 
   # Stream from specific targets (multi-target config)
-  haloy logs --targets prod`,
+  haloy logs --targets prod
+
+  # Raw dump (no follow, no extra formatting)
+  haloy logs --raw`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
@@ -78,7 +82,7 @@ Examples:
 					if len(targets) > 1 {
 						prefix = target.TargetName
 					}
-					return streamAppLogs(ctx, &target, target.Server, target.Name, tail, containerID, allContainers, prefix)
+					return streamAppLogs(ctx, &target, target.Server, target.Name, tail, containerID, allContainers, raw, prefix)
 				})
 			}
 
@@ -89,16 +93,17 @@ Examples:
 	cmd.Flags().StringVarP(&flags.configPath, "config", "c", "", "Path to config file or directory (default: .)")
 	cmd.Flags().StringSliceVarP(&flags.targets, "targets", "t", nil, "Stream logs for specific targets (comma-separated)")
 	cmd.Flags().BoolVarP(&flags.all, "all", "a", false, "Stream logs for all targets")
-	cmd.Flags().IntVar(&tail, "tail", 100, "Number of historical log lines to show")
+	cmd.Flags().IntVar(&tail, "tail", 100, "Number of historical log lines to show (default: 100)")
 	cmd.Flags().StringVar(&containerID, "container", "", "Stream logs from a specific container ID")
 	cmd.Flags().BoolVar(&allContainers, "all-containers", false, "Stream logs from all containers")
+	cmd.Flags().BoolVar(&raw, "raw", false, "Raw dump (no follow, no extra formatting)")
 
 	cmd.RegisterFlagCompletionFunc("targets", completeTargetNames)
 
 	return cmd
 }
 
-func streamAppLogs(ctx context.Context, targetConfig *config.TargetConfig, targetServer, appName string, tail int, containerID string, allContainers bool, prefix string) error {
+func streamAppLogs(ctx context.Context, targetConfig *config.TargetConfig, targetServer, appName string, tail int, containerID string, allContainers, raw bool, prefix string) error {
 	pui := &ui.PrefixedUI{Prefix: prefix}
 
 	token, err := getToken(targetConfig, targetServer)
@@ -111,7 +116,9 @@ func streamAppLogs(ctx context.Context, targetConfig *config.TargetConfig, targe
 		return &PrefixedError{Err: fmt.Errorf("failed to create API client: %w", err), Prefix: prefix}
 	}
 
-	pui.Info("Streaming container logs... (Press Ctrl+C to stop)")
+	if !raw {
+		pui.Info("Streaming container logs... (Press Ctrl+C to stop)")
+	}
 
 	params := url.Values{}
 	params.Set("tail", strconv.Itoa(tail))
@@ -121,10 +128,13 @@ func streamAppLogs(ctx context.Context, targetConfig *config.TargetConfig, targe
 	if allContainers {
 		params.Set("allContainers", "true")
 	}
+	if raw {
+		params.Set("follow", "false")
+	}
 
 	path := fmt.Sprintf("logs/%s?%s", appName, params.Encode())
 
-	showContainerID := allContainers
+	showContainerID := allContainers && !raw
 
 	streamHandler := func(data string) bool {
 		var logLine docker.LogLine
@@ -142,7 +152,7 @@ func streamAppLogs(ctx context.Context, targetConfig *config.TargetConfig, targe
 			line = fmt.Sprintf("[%s] %s", shortID, logLine.Line)
 		}
 
-		if prefix != "" {
+		if prefix != "" && !raw {
 			pui.Info("%s", line)
 		} else {
 			fmt.Println(line)


### PR DESCRIPTION
Added `--raw` and `--no-follow` flags to the `haloy logs` command.

- `--no-follow`: Print existing logs and exit (no streaming).
- `--raw`: Output plain logs with no extra formatting, prefixes, or container names.

Useful for easier parsing, scripting, and tool integration.

Servers with older `haloyd` ignore the `--no-follow` flag and keep streaming. I hope that's not a big issue.